### PR TITLE
Enhance Telegram shop UI

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,3 +3,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 ADMIN_ID = os.getenv("ADMIN_ID")
+
+# Phone number for contacting the manager
+MANAGER_PHONE = "+998 90 988 38 34"

--- a/handlers.py
+++ b/handlers.py
@@ -1,9 +1,19 @@
 from aiogram import Router, F
 from aiogram.filters import Command
 from aiogram.types import Message, CallbackQuery, FSInputFile, InlineKeyboardMarkup, InlineKeyboardButton
-from keyboards import categories_keyboard, subcategories_keyboard, products_keyboard, buy_keyboard
+from keyboards import (
+    categories_keyboard,
+    subcategories_keyboard,
+    products_keyboard,
+    buy_keyboard,
+    category_keyboard,
+    cart_keyboard,
+    orders_keyboard,
+    manager_keyboard,
+    CATEGORY_EMOJIS,
+)
 from products import products
-from config import ADMIN_ID
+from config import ADMIN_ID, MANAGER_PHONE
 
 router = Router()
 
@@ -16,22 +26,20 @@ PROMOCODES = {
     "BOOM10": 0.10,  # Промокод на 10% скидку
 }
 
-MANAGER_PHONE = "+998 90 988 38 34"
-
 # ✅ /start
 @router.message(Command("start"))
 async def start(message: Message):
     subscribers.add(message.from_user.id)
-    await message.answer(
-        "Добро пожаловать в 🛍️ <b>ShopBoom!</b>\n\nВыберите категорию товара:",
-        reply_markup=categories_keyboard(),
-        parse_mode="HTML"
-    )
-    await message.answer(
-        "Если нужна помощь, свяжитесь с менеджером 📞\n\n"
-        f"<b>Телефон менеджера:</b> {MANAGER_PHONE}",
-        parse_mode="HTML"
-    )
+    await message.answer("Добро пожаловать в 🛍️ <b>ShopBoom!</b>", parse_mode="HTML")
+    for category in products.keys():
+        await message.answer(
+            f"{CATEGORY_EMOJIS.get(category, '')} <b>{category}</b>",
+            reply_markup=category_keyboard(category),
+            parse_mode="HTML",
+        )
+    await message.answer("🛒 <b>Корзина</b>", reply_markup=cart_keyboard(), parse_mode="HTML")
+    await message.answer("📦 <b>Мои заказы</b>", reply_markup=orders_keyboard(), parse_mode="HTML")
+    await message.answer("📞 <b>Связаться с менеджером</b>", reply_markup=manager_keyboard(), parse_mode="HTML")
 
 # ✅ /myorders
 @router.message(Command("myorders"))
@@ -51,6 +59,25 @@ async def my_orders(message: Message):
             f"Адрес: {order['address']}\n\n"
         )
     await message.answer(text, parse_mode="HTML")
+
+
+@router.callback_query(F.data == "my_orders")
+async def my_orders_cb(callback: CallbackQuery):
+    history = user_order_history.get(callback.from_user.id, [])
+    if not history:
+        await callback.message.answer("🛒 У вас пока нет оформленных заказов.")
+        return
+
+    text = "📋 <b>Ваши заказы:</b>\n\n"
+    for idx, order in enumerate(history, start=1):
+        text += (
+            f"#{idx} — <b>{order['product']}</b>\n"
+            f"Размер: {order['size']}\n"
+            f"Цена: {int(order['final_price']):,} сум\n"
+            f"Телефон: {order['phone']}\n"
+            f"Адрес: {order['address']}\n\n"
+        )
+    await callback.message.answer(text, parse_mode="HTML")
 
 # ✅ Назад к категориям
 @router.callback_query(F.data == "back_to_main")
@@ -103,9 +130,14 @@ async def show_product(callback: CallbackQuery):
                     photo = FSInputFile(item["photo"])
                     await callback.message.answer_photo(
                         photo=photo,
-                        caption=f"<b>{item['name']}</b>\n\n{item['description']}\n\n💵 <b>{item['price']:,} сум</b>",
+                        caption=(
+                            f"🛍️ <b>{item['name']}</b>\n"
+                            f"💸 <b>Цена:</b> <code>{item['price']:,} сум</code>\n"
+                            "📏 <b>Размеры:</b> S, M, L, XL\n"
+                            f"📄 <b>Описание:</b> {item['description']}"
+                        ),
                         reply_markup=buy_keyboard(product_id),
-                        parse_mode="HTML"
+                        parse_mode="HTML",
                     )
                     return
 
@@ -133,6 +165,32 @@ async def choose_size(callback: CallbackQuery):
 async def cancel_order(callback: CallbackQuery):
     user_orders.pop(callback.from_user.id, None)
     await callback.message.answer("❌ Ваш заказ был отменён.")
+
+
+@router.callback_query(F.data == "cart")
+async def show_cart(callback: CallbackQuery):
+    await callback.message.answer("🛒 Ваша корзина пока пуста.")
+
+
+@router.callback_query(F.data == "contact_manager")
+async def contact_manager(callback: CallbackQuery):
+    await callback.message.answer(
+        f"<b>Телефон менеджера:</b> {MANAGER_PHONE}", parse_mode="HTML"
+    )
+
+
+@router.callback_query(F.data.startswith("more:"))
+async def show_more(callback: CallbackQuery):
+    product_id = int(callback.data.split(":")[1])
+    for cat in products.values():
+        for subcat in cat.values():
+            for item in subcat:
+                if item["id"] == product_id:
+                    await callback.message.answer(
+                        f"📄 <b>Описание товара:</b> {item['description']}",
+                        parse_mode="HTML",
+                    )
+                    return
 
 # ✅ Выбор размера → Промокод
 @router.callback_query(F.data.startswith("size:"))

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,15 +1,53 @@
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from products import products
+from config import MANAGER_PHONE
 
-# Клавиатура категорий
-def categories_keyboard():
-    keyboard = InlineKeyboardMarkup(
+# Emojis for categories
+CATEGORY_EMOJIS = {
+    "Одежда": "👗",
+    "Обувь": "👟"
+}
+
+
+def category_keyboard(category: str) -> InlineKeyboardMarkup:
+    """Keyboard with a single category button."""
+    emoji = CATEGORY_EMOJIS.get(category, "")
+    return InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text=category, callback_data=f"category:{category}")]
-            for category in products.keys()
+            [InlineKeyboardButton(text=f"{emoji} {category}", callback_data=f"category:{category}")]
         ]
     )
-    return keyboard
+
+
+def cart_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="🛒 Корзина", callback_data="cart")]]
+    )
+
+
+def orders_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="📦 Мои заказы", callback_data="my_orders")]]
+    )
+
+
+def manager_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="📞 Связаться с менеджером", url=f"tel:{MANAGER_PHONE}")]]
+    )
+
+# Клавиатура категорий
+def categories_keyboard() -> InlineKeyboardMarkup:
+    """Main menu keyboard with categories and service buttons."""
+    buttons = [
+        [InlineKeyboardButton(text=f"{CATEGORY_EMOJIS.get(cat, '')} {cat}", callback_data=f"category:{cat}")]
+        for cat in products.keys()
+    ]
+    buttons.append([InlineKeyboardButton(text="🛒 Корзина", callback_data="cart")])
+    buttons.append([InlineKeyboardButton(text="📦 Мои заказы", callback_data="my_orders")])
+    buttons.append([InlineKeyboardButton(text="📞 Связаться с менеджером", callback_data="contact_manager")])
+
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 # Клавиатура подкатегорий
 def subcategories_keyboard(category):
@@ -38,6 +76,7 @@ def buy_keyboard(product_id):
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text="🛒 Купить", callback_data=f"buy:{product_id}")],
+            [InlineKeyboardButton(text="ℹ️ Подробнее", callback_data=f"more:{product_id}")],
             [InlineKeyboardButton(text="⬅️ Назад", callback_data="back_to_main")]
         ]
     )


### PR DESCRIPTION
## Summary
- redesign start menu with separate emoji buttons
- add service keyboards for cart, orders and manager contact
- show product cards with formatted caption and extra button
- expose manager phone in config

## Testing
- `python -m py_compile bot.py handlers.py keyboards.py products.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6858eb4bc4ec83249b10a63a2ee5615a